### PR TITLE
feat: add an interactive completing-read interface

### DIFF
--- a/noman.el
+++ b/noman.el
@@ -152,7 +152,17 @@ Noman (no-man) has similar keybindings to man:
 g/m  -  jump to a subcommand
 G    -  view help for a different command
 l    -  go back to the last subcommand"
-  (interactive (list (read-shell-command "Command: ")))
+  (interactive (let* ((paths (exec-path))
+                      (commands '()))
+                 (dolist (path paths)
+                   (when (file-directory-p path)
+                     (setq commands
+                           (append commands
+                                   (directory-files path t "^[^.].*")))))
+                 (setq commands (seq-filter #'file-executable-p commands))
+                 (setq commands (mapcar #'file-name-nondirectory commands))
+                 (list
+                  (completing-read "Program: " commands nil t))))
   (push cmd noman--history)
   (let* ((buffer (get-buffer-create (format "*noman %s*" cmd)))
          (cmdprefix (car (split-string cmd)))


### PR DESCRIPTION
This commit introduces an interactive prompt for selecting the program for which to display the help menu.

Since it's using the `completing-read` interface, it should work for all completion frameworks that rely on it (eg.: vertico).

Screenshots:
![image](https://github.com/andykuszyk/noman.el/assets/54212424/dffcf1f5-be17-4ca8-af1b-c79dd5a91131)
![image](https://github.com/andykuszyk/noman.el/assets/54212424/bc5c0d07-2265-4a4f-a05f-e6d72cb64d13)